### PR TITLE
updated to python3

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-warehouse-ros
 	pkgdesc = ROS - Persistent storage of ROS messages.
 	pkgver = 0.9.3
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/warehouse_ros
 	arch = any
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/warehouse_ros'
 pkgname='ros-melodic-warehouse-ros'
 pkgver='0.9.3'
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(ros-melodic-tf
@@ -49,17 +49,17 @@ build() {
   cd ${srcdir}/build
 
   # Fix Python2/Python3 conflicts
-  /usr/share/ros-build-tools/fix-python-scripts.sh -v 2 ${srcdir}/${_dir}
+  /usr/share/ros-build-tools/fix-python-scripts.sh -v 3 ${srcdir}/${_dir}
 
   # Build project
   cmake ${srcdir}/${_dir} \
         -DCMAKE_BUILD_TYPE=Release \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \
-        -DPYTHON_EXECUTABLE=/usr/bin/python2 \
-        -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
-        -DPYTHON_LIBRARY=/usr/lib/libpython2.7.so \
-        -DPYTHON_BASENAME=-python2.7 \
+        -DPYTHON_EXECUTABLE=/usr/bin/python3 \
+        -DPYTHON_INCLUDE_DIR=/usr/include/python3.8 \
+        -DPYTHON_LIBRARY=/usr/lib/libpython3.8.so \
+        -DPYTHON_BASENAME=.cpython-38 \
         -DSETUPTOOLS_DEB_LAYOUT=OFF
   make
 }


### PR DESCRIPTION
No idea how this evaded us. It genuinely failed without changing the `-DPYTHON_EXECUTABLE` so this may be a package that relies on those. I don't have time to dig in, but it for sure needed to be updated to python3 in some aspect.